### PR TITLE
[ARC302 Well-Architected] Configure Comprehensive Service and Application Logging

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/lambda/apigw-handler/index.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/lambda/apigw-handler/index.py
@@ -20,36 +20,62 @@ dynamodb_client = boto3.client("dynamodb")
 
 def handler(event, context):
     table = os.environ.get("TABLE_NAME")
-    logging.info(f"## Loaded table name from environemt variable DDB_TABLE: {table}")
-    if event["body"]:
-        item = json.loads(event["body"])
-        logging.info(f"## Received payload: {item}")
-        year = str(item["year"])
-        title = str(item["title"])
-        id = str(item["id"])
-        dynamodb_client.put_item(
-            TableName=table,
-            Item={"year": {"N": year}, "title": {"S": title}, "id": {"S": id}},
-        )
-        message = "Successfully inserted data!"
+    request_id = context.request_id
+    
+    # Log request context for security and audit purposes
+    logger.info(f"Request ID: {request_id}")
+    logger.info(f"Table name: {table}")
+    
+    # Extract source IP from request context
+    source_ip = event.get('requestContext', {}).get('identity', {}).get('sourceIp', 'unknown')
+    logger.info(f"Source IP: {source_ip}")
+    
+    try:
+        if event["body"]:
+            item = json.loads(event["body"])
+            item_id = item.get('id', 'unknown')
+            logger.info(f"Processing item with id: {item_id}")
+            
+            year = str(item["year"])
+            title = str(item["title"])
+            id = str(item["id"])
+            
+            dynamodb_client.put_item(
+                TableName=table,
+                Item={"year": {"N": year}, "title": {"S": title}, "id": {"S": id}},
+            )
+            
+            logger.info(f"Successfully inserted item with id: {item_id}")
+            message = "Successfully inserted data!"
+            return {
+                "statusCode": 200,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"message": message}),
+            }
+        else:
+            logger.info("Received request without a payload, inserting default data")
+            default_id = str(uuid.uuid4())
+            
+            dynamodb_client.put_item(
+                TableName=table,
+                Item={
+                    "year": {"N": "2012"},
+                    "title": {"S": "The Amazing Spider-Man 2"},
+                    "id": {"S": default_id},
+                },
+            )
+            
+            logger.info(f"Successfully inserted default item with id: {default_id}")
+            message = "Successfully inserted data!"
+            return {
+                "statusCode": 200,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"message": message}),
+            }
+    except Exception as e:
+        logger.error(f"Error processing request: {str(e)}", exc_info=True)
         return {
-            "statusCode": 200,
+            "statusCode": 500,
             "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({"message": message}),
-        }
-    else:
-        logging.info("## Received request without a payload")
-        dynamodb_client.put_item(
-            TableName=table,
-            Item={
-                "year": {"N": "2012"},
-                "title": {"S": "The Amazing Spider-Man 2"},
-                "id": {"S": str(uuid.uuid4())},
-            },
-        )
-        message = "Successfully inserted data!"
-        return {
-            "statusCode": 200,
-            "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({"message": message}),
+            "body": json.dumps({"message": "Internal server error"}),
         }

--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -9,7 +9,10 @@ from aws_cdk import (
     aws_apigateway as apigw_,
     aws_ec2 as ec2,
     aws_iam as iam,
+    aws_logs as logs,
+    aws_s3 as s3,
     Duration,
+    RemovalPolicy,
 )
 from constructs import Construct
 
@@ -31,6 +34,28 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
                     cidr_mask=24
                 )
             ],
+        )
+        
+        # Create S3 bucket for VPC Flow Logs
+        flow_logs_bucket = s3.Bucket(
+            self,
+            "VpcFlowLogsBucket",
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            lifecycle_rules=[
+                s3.LifecycleRule(
+                    expiration=Duration.days(365),
+                )
+            ],
+            removal_policy=RemovalPolicy.DESTROY,
+            auto_delete_objects=True,
+        )
+        
+        # Enable VPC Flow Logs
+        vpc.add_flow_log(
+            "FlowLog",
+            destination=ec2.FlowLogDestination.to_s3(flow_logs_bucket),
+            traffic_type=ec2.FlowLogTrafficType.ALL,
         )
         
         # Create VPC endpoint
@@ -65,6 +90,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             partition_key=dynamodb_.Attribute(
                 name="id", type=dynamodb_.AttributeType.STRING
             ),
+            point_in_time_recovery=True,
         )
 
         # Create the Lambda function to receive the request
@@ -82,11 +108,20 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             memory_size=1024,
             timeout=Duration.minutes(5),
             tracing=lambda_.Tracing.ACTIVE,
+            log_retention=logs.RetentionDays.ONE_YEAR,
         )
 
         # grant permission to lambda to write to demo table
         demo_table.grant_write_data(api_hanlder)
         api_hanlder.add_environment("TABLE_NAME", demo_table.table_name)
+
+        # Create log group for API Gateway access logs
+        api_log_group = logs.LogGroup(
+            self,
+            "ApiGatewayAccessLogs",
+            retention=logs.RetentionDays.ONE_YEAR,
+            removal_policy=RemovalPolicy.DESTROY,
+        )
 
         # Create API Gateway
         apigw_.LambdaRestApi(
@@ -95,5 +130,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             handler=api_hanlder,
             deploy_options=apigw_.StageOptions(
                 tracing_enabled=True,
+                access_log_destination=apigw_.LogGroupLogDestination(api_log_group),
+                access_log_format=apigw_.AccessLogFormat.json_with_standard_fields(),
             ),
         )


### PR DESCRIPTION
## Summary

This PR implements comprehensive service and application logging across the API Gateway, Lambda, VPC, and DynamoDB stack to enable security investigations, audit compliance, and operational visibility. This addresses AWS Well-Architected Framework best practice SEC04-BP01 for configuring service and application logging.

## Changes Made

### API Gateway Access Logging
- Created CloudWatch Log Group for API Gateway access logs with 1-year retention
- Configured API Gateway to send access logs with JSON format including standard fields
- Logs capture request/response details, caller identity, and timing information

### Lambda CloudWatch Logs Retention
- Added explicit log retention policy of 1 year to Lambda function
- Ensures compliance with audit requirements while managing storage costs
- CDK automatically creates and manages the log group

### VPC Flow Logs
- Created S3 bucket for VPC Flow Logs with server-side encryption
- Configured bucket with 1-year lifecycle policy and block public access
- Enabled VPC Flow Logs to capture ALL traffic (accepted and rejected)
- Provides network-level visibility for security investigations

### Enhanced Application Logging
- Added request ID logging for request correlation
- Added source IP logging from API Gateway request context
- Added operation success/failure logging with item IDs
- Implemented try/except error handling with detailed error logging
- Added proper error responses with 500 status code
- Logs now support security event reconstruction and troubleshooting

### DynamoDB Point-in-Time Recovery
- Enabled PITR on DynamoDB table for continuous backups
- Provides audit trail for data modification events
- Enables recovery to any point in time within 35 days

### Infrastructure Updates
- Imported `aws_logs` and `aws_s3` modules in CDK stack
- Added `RemovalPolicy.DESTROY` for development/testing environments
- All logging resources properly configured with lifecycle policies

## Well-Architected Framework Compliance

These changes implement **SEC04-BP01: Configure service and application logging**. Without proper logging, security events and API activity may not be captured for audit, investigations, or compliance purposes, creating significant risk during security incidents.

✅ **Security Event Capture**: API Gateway access logs, Lambda logs, and VPC Flow Logs provide comprehensive visibility into all system activity

✅ **Audit Trail**: Request IDs, source IPs, and operation results enable reconstruction of activity timelines during investigations

✅ **Compliance Ready**: 1-year log retention meets common regulatory requirements (adjust as needed for specific compliance frameworks)

✅ **Incident Response**: Detailed logging enables faster root cause analysis and reduces mean time to resolution (MTTR)

✅ **Network Visibility**: VPC Flow Logs enable investigation of network-level security events and unauthorized access attempts

✅ **Data Protection**: DynamoDB PITR provides continuous backups and audit capabilities for data modification events

## Testing

After deployment:
1. Navigate to CloudWatch Logs console and verify log groups exist:
   - `/aws/lambda/apigw_handler` (with 1-year retention)
   - API Gateway access logs group (with 1-year retention)
2. Send test requests to API Gateway endpoint
3. Verify access logs appear in CloudWatch with request details
4. Verify Lambda logs include request ID, source IP, and operation details
5. Check S3 bucket for VPC Flow Logs (may take 10-15 minutes to appear)
6. Verify DynamoDB table has PITR enabled in console
7. Test error handling by sending invalid payload and verify error logging

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added comprehensive logging configuration for all services
- `python/apigw-http-api-lambda-dynamodb-python-cdk/lambda/apigw-handler/index.py` - Enhanced application logging with security context and error handling

Fixes #2